### PR TITLE
(SIMP-6921) Update deps and fix tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,9 @@
 fixtures:
   repositories:
     auditd:               "https://github.com/simp/pupmod-simp-auditd"
+    augeas_core:
+      repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
+      puppet_version: ">= 6.0.0"
     augeasproviders_core: "https://github.com/simp/augeasproviders_core"
     augeasproviders_grub: "https://github.com/simp/augeasproviders_grub"
     concat:               "https://github.com/simp/puppetlabs-concat"
@@ -13,7 +16,6 @@ fixtures:
     pki:                  "https://github.com/simp/pupmod-simp-pki"
     polkit:               "https://github.com/simp/pupmod-simp-polkit"
     rsyslog:              "https://github.com/simp/pupmod-simp-rsyslog"
-    simpcat:              "https://github.com/simp/pupmod-simp-simpcat"
     simplib:              "https://github.com/simp/pupmod-simp-simplib"
     stdlib:               "https://github.com/simp/puppetlabs-stdlib"
   symlinks:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,14 +5,11 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.1      4.10.6   2.1.9  TBD
-# SIMP 6.2      4.10.12  2.1.9  TBD
-# SIMP 6.3      5.5.7    2.4.4  TBD***
-# PE 2018.1     5.5.8    2.4.4  2020-05 (LTS)***
+# SIMP 6.3      5.5.10   2.4.5  TBD***
+# PE 2018.1     5.5.8    2.4.5  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
-# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 ---
 stages:
   - 'sanity'
@@ -65,18 +62,6 @@ variables:
 # Puppet Versions
 #-----------------------------------------------------------------------
 
-.pup_4: &pup_4
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.0'
-    MATRIX_RUBY_VERSION: '2.1'
-
-.pup_4_10: &pup_4_10
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.10.4'
-    MATRIX_RUBY_VERSION: '2.1'
-
 .pup_5: &pup_5
   image: 'ruby:2.4'
   variables:
@@ -84,21 +69,19 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_5_5_7: &pup_5_5_7
+.pup_5_5_10: &pup_5_5_10
   image: 'ruby:2.4'
   variables:
-    PUPPET_VERSION: '5.5.7'
+    PUPPET_VERSION: '5.5.10'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
 .pup_6: &pup_6
-  allow_failure: true
   image: 'ruby:2.5'
   variables:
     PUPPET_VERSION: '~> 6.0'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
-
 
 # Testing Environments
 #-----------------------------------------------------------------------
@@ -151,10 +134,6 @@ sanity_checks:
 # Linting
 #-----------------------------------------------------------------------
 
-pup4-lint:
-  <<: *pup_4
-  <<: *lint_tests
-
 pup5-lint:
   <<: *pup_5
   <<: *lint_tests
@@ -170,48 +149,49 @@ pup5-unit:
   <<: *pup_5
   <<: *unit_tests
 
-pup5.5.7-unit:
-  <<: *pup_5_5_7
-  <<: *unit_tests
-
-pup4.10-unit:
-  <<: *pup_4_10
+pup5.5.10-unit:
+  <<: *pup_5_5_10
   <<: *unit_tests
 
 pup6-unit:
   <<: *pup_6
   <<: *unit_tests
 
-# Acceptance Tests
-#-----------------------------------------------------------------------
-
-pup4.10:
-  <<: *pup_4_10
+# Acceptance tests
+# ==============================================================================
+pup5.5.10:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites'
 
-pup4.10-fips:
-  <<: *pup_4_10
-  <<: *acceptance_base
-  <<: *only_with_SIMP_FULL_MATRIX
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
-
-pup5.5.7:
-  <<: *pup_5_5_7
-  <<: *acceptance_base
-  script:
-    - 'bundle exec rake beaker:suites'
-
-pup5.5.7-fips:
-  <<: *pup_5_5_7
+pup5.5.10-fips:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites'
 
-pup5.5.7-oel:
-  <<: *pup_5_5_7
+pup5.5.10-oel:
+  <<: *pup_5_5_10
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,oel-combined-x64]'
+
+pup5.5.10-oel-fips:
+  <<: *pup_5_5_10
+  <<: *acceptance_base
+  <<: *only_with_SIMP_FULL_MATRIX
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel-combined-x64]'
+
+pup6:
+  <<: *pup_6
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites'
+
+pup6-fips:
+  <<: *pup_6
+  <<: *acceptance_base
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites'

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,10 @@ global:
   - STRICT_VARIABLES=yes
 
 jobs:
-  allow_failures:
-    - name: 'Latest Puppet 6.x (allowed to fail)'
-
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
@@ -62,21 +59,14 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      name: 'Puppet 4.10 (SIMP 6.2, PE 2016.4)'
-      rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.10.0"
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
       name: 'Puppet 5.3 (PE 2017.3)'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.3.0"
       script:
         - bundle exec rake spec
 
     - stage: spec
-      rvm: 2.4.4
+      rvm: 2.4.5
       name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1)'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
@@ -84,20 +74,20 @@ jobs:
 
     - stage: spec
       name: 'Latest Puppet 5.x'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
 
     - stage: spec
-      name: 'Latest Puppet 6.x (allowed to fail)'
+      name: 'Latest Puppet 6.x'
       rvm: 2.5.1
       env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec
 
     - stage: deploy
-      rvm: 2.4.4
+      rvm: 2.4.5
       script:
         - true
       before_deploy:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
-* Fri Aug 02 2019 Robert Vincent <pillarsdotnet@gmail.com> - 0.2.2
-- Support puppetlabs/stdlib 6.x and puppet 6.x.
+* Fri Aug 02 2019 Robert Vincent <pillarsdotnet@gmail.com> - 0.3.0
+- Remove Puppet 4 support
+- Add Puppet 6 support
+- Add puppetlabs-stdlib 6 support
 
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.2.1
 - Update the upper bound of stdlib to < 6.0.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Aug 02 2019 Robert Vincent <pillarsdotnet@gmail.com> - 0.2.2
+- Support puppetlabs/stdlib 6.x and puppet 6.x.
+
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.2.1
 - Update the upper bound of stdlib to < 6.0.0
 - Update a URL in the README.md

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-x2go",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "author": "simp",
   "summary": "Puppet module for managing x2go server and client",
   "license": "Apache-2.0",
@@ -58,7 +58,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.4 < 7.0.0"
+      "version_requirement": ">= 5.0.0 < 7.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-x2go",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "simp",
   "summary": "Puppet module for managing x2go server and client",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.13.1 < 7.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -58,7 +58,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.4 < 6.0.0"
+      "version_requirement": ">= 4.10.4 < 7.0.0"
     }
   ]
 }

--- a/spec/acceptance/nodesets/centos-combined-x64.yml
+++ b/spec/acceptance/nodesets/centos-combined-x64.yml
@@ -19,7 +19,7 @@ HOSTS:
       epel:
         mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
         gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   el6:
     roles:
@@ -31,7 +31,7 @@ HOSTS:
       epel:
         mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
         gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/oel-combined-x64.yml
+++ b/spec/acceptance/nodesets/oel-combined-x64.yml
@@ -19,7 +19,7 @@ HOSTS:
       epel:
         mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
         gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   el6:
     roles:
@@ -31,7 +31,7 @@ HOSTS:
       epel:
         mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
         gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose


### PR DESCRIPTION
- Support puppet 6.x
- Support puppetlabs/stdlib 6.x
- Fix EPEL key URLs in tests
- Drop support for puppet 4.x\

SIMP-6919 #comment pupmod-simp-x2go
SIMP-6909 #comment pupmod-simp-x2go
SIMP-6934 #comment pupmod-simp-x2go
